### PR TITLE
Removing some star imports 

### DIFF
--- a/calc_timing.py
+++ b/calc_timing.py
@@ -5,12 +5,11 @@ os.environ['OPENBLAS_NUM_THREADS'] = '1'    # to run numpy single threaded
 import torch
 import time
 
-from models.vae_flow import *
 from configs import Configs
 
 import utils.gen_utils as gen_utils
 
-from models.shower_flow import compile_HybridTanH_model, compile_HybridTanH_model_s
+from models.shower_flow import compile_HybridTanH_model
 import models.CaloClouds_2 as mdls
 import models.CaloClouds_1 as mdls2
 

--- a/distillation.py
+++ b/distillation.py
@@ -4,11 +4,13 @@ import torch
 from torch.utils.data import DataLoader
 from torch.nn.utils import clip_grad_norm_
 
-from utils.dataset import *
-from utils.misc import *
-from models.vae_flow import *
+from utils.dataset import PointCloudDataset, PointCloudDatasetGH
+from utils.misc import seed_all, get_new_log_dir, CheckpointManager
+from models.vae_flow import VAEFlow
 from models.CaloClouds_2 import CaloClouds_2
 from configs import Configs
+
+import time
 
 
 def main():

--- a/models/CaloClouds_2.py
+++ b/models/CaloClouds_2.py
@@ -1,5 +1,6 @@
 import torch
-from torch.nn import Module
+from torch.nn import Module, ModuleList
+import torch.nn.functional as F
 
 from .common import *
 from .encoders.epic_encoder_cond import EPiC_encoder_cond

--- a/models/CaloClouds_2.py
+++ b/models/CaloClouds_2.py
@@ -3,8 +3,13 @@ from torch.nn import Module, ModuleList
 import torch.nn.functional as F
 
 from .common import ConcatSquashLinear, KLDloss, reparameterize_gaussian
-from .misc import get_flow_model, mean_flat
 from .encoders.epic_encoder_cond import EPiC_encoder_cond
+
+# This import is a bit fragile, it only works if the directory above is on the python path
+# That happens natrually if the directory above is where you started python
+# but we could fix it by either expicitly adding the directory above to the path
+# or by making a deeper directory structure so thi could be a relative import
+from utils.misc import get_flow_model, mean_flat
 
 import k_diffusion as K
 

--- a/models/diffusion.py
+++ b/models/diffusion.py
@@ -3,7 +3,7 @@ import torch.nn.functional as F
 from torch.nn import Module, Parameter, ModuleList
 import numpy as np
 
-from .common import *
+from .common import ConcatSquashLinear
 
 
 class VarianceSchedule(Module):

--- a/models/encoders/pointnet.py
+++ b/models/encoders/pointnet.py
@@ -1,0 +1,51 @@
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+class PointNetEncoder(nn.Module):
+    def __init__(self, zdim, input_dim=4):
+        super().__init__()
+        self.zdim = zdim
+        self.conv1 = nn.Conv1d(input_dim, 128, 1)
+        self.conv2 = nn.Conv1d(128, 128, 1)
+        self.conv3 = nn.Conv1d(128, 256, 1)
+        self.conv4 = nn.Conv1d(256, 512, 1)
+        self.bn1 = nn.BatchNorm1d(128)
+        self.bn2 = nn.BatchNorm1d(128)
+        self.bn3 = nn.BatchNorm1d(256)
+        self.bn4 = nn.BatchNorm1d(512)
+
+        # Mapping to [c], cmean
+        self.fc1_m = nn.Linear(512, 256)
+        self.fc2_m = nn.Linear(256, 128)
+        self.fc3_m = nn.Linear(128, zdim)
+        self.fc_bn1_m = nn.BatchNorm1d(256)
+        self.fc_bn2_m = nn.BatchNorm1d(128)
+
+        # Mapping to [c], cmean
+        self.fc1_v = nn.Linear(512, 256)
+        self.fc2_v = nn.Linear(256, 128)
+        self.fc3_v = nn.Linear(128, zdim)
+        self.fc_bn1_v = nn.BatchNorm1d(256)
+        self.fc_bn2_v = nn.BatchNorm1d(128)
+
+    def forward(self, x):
+        x = x.transpose(1, 2)
+        x = F.relu(self.bn1(self.conv1(x)))
+        x = F.relu(self.bn2(self.conv2(x)))
+        x = F.relu(self.bn3(self.conv3(x)))
+        x = self.bn4(self.conv4(x))
+        x = torch.max(x, 2, keepdim=True)[0]
+        x = x.view(-1, 512)
+
+        m = F.relu(self.fc_bn1_m(self.fc1_m(x)))
+        m = F.relu(self.fc_bn2_m(self.fc2_m(m)))
+        m = self.fc3_m(m)
+        v = F.relu(self.fc_bn1_v(self.fc1_v(x)))
+        v = F.relu(self.fc_bn2_v(self.fc2_v(v)))
+        v = self.fc3_v(v)
+
+        # Returns both mean and logvariance, just ignore the latter in deteministic cases.
+        return m, v
+

--- a/models/shower_flow.py
+++ b/models/shower_flow.py
@@ -4,7 +4,7 @@ import torch.nn as nn
 from pyro.nn import ConditionalDenseNN, DenseNN
 import pyro.distributions as dist
 import pyro.distributions.transforms as T
-from custom_pyro import ConditionalAffineCouplingTanH
+from .custom_pyro import ConditionalAffineCouplingTanH
 
 
 def compile_HybridTanH_model(num_blocks, num_inputs, num_cond_inputs, device):

--- a/models/vae_flow.py
+++ b/models/vae_flow.py
@@ -1,13 +1,12 @@
 import torch
 from torch.nn import Module
 
-from .common import *
-from .encoders import *
-from .diffusion import *
-from .flow import *
+from .common import reparameterize_gaussian, gaussian_entropy, standard_normal_logprob, truncated_normal_
+from .encoders.pointnet import PointNetEncoder
+from .diffusion import DiffusionPoint
 
 
-class FlowVAE(Module):
+class VAEFlow(Module):
 
     def __init__(self, args):
         super().__init__()

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ wurlitzer==3.0.3
 zipp==3.11.0
 pyro-ppl
 nflows
+pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,5 @@ Werkzeug==2.2.3
 wrapt==1.14.1
 wurlitzer==3.0.3
 zipp==3.11.0
+pyro-ppl
+nflows

--- a/training.py
+++ b/training.py
@@ -4,14 +4,17 @@ import torch
 from torch.utils.data import DataLoader
 from torch.nn.utils import clip_grad_norm_
 
-from utils.dataset import *
-from utils.misc import *
-from models.vae_flow import *
+#from utils.dataset import *
+#from utils.misc import *
+from utils.misc import seed_all, get_new_log_dir, CheckpointManager
+#from models.vae_flow import *
 from models.CaloClouds_1 import CaloClouds_1
 from models.CaloClouds_2 import CaloClouds_2
 from configs import Configs
 
 import k_diffusion as K
+
+import time
 
 cfg = Configs()
 seed_all(seed = cfg.seed)

--- a/training.py
+++ b/training.py
@@ -4,10 +4,9 @@ import torch
 from torch.utils.data import DataLoader
 from torch.nn.utils import clip_grad_norm_
 
-#from utils.dataset import *
-#from utils.misc import *
+from utils.dataset import PointCloudDataset
 from utils.misc import seed_all, get_new_log_dir, CheckpointManager
-#from models.vae_flow import *
+from models.common import get_linear_scheduler
 from models.CaloClouds_1 import CaloClouds_1
 from models.CaloClouds_2 import CaloClouds_2
 from configs import Configs


### PR DESCRIPTION
Exchanged some star imports for direct imports. 

The module `vae_flow.py` tries to import a local module `.flows`, which doesn't exist. Previously this created an error when running `training.py`. As it's not needed for `training.py` anyway, the error can be resolved by just refining the imports.

Has an indirect effect on `CaloClouds_2` which was relying on star import to pull things in from common.

~Will test `distillation.py` and `calc_timing.py` before I take this out of draft.~ Done.

Problems remain in `ShowerFlow.pynb`, and potentially in `calc_timing.py` since it requires the output of `ShowerFlow.pynb` to run, but these problem are not import related so I won't try and include the fixes here. (The object `clusters_per_layer` is used before it's created.)

Both `training.py` and `distilation.py` now run when the appropriate data has been made accessible.